### PR TITLE
HW: PyVCAM adapter

### DIFF
--- a/copylot/gui/_qt/dockables/camera.py
+++ b/copylot/gui/_qt/dockables/camera.py
@@ -18,30 +18,17 @@ class CameraDockWidget(QWidget):
         self.parent = parent
 
         self.main_layout = QHBoxLayout()
-        self.power_button = QPushButton("Power")
-        self.power_button.clicked.connect(self.power_button.toggle)
-        self.main_layout.addWidget(self.power_button)
-
-        self.main_layout.addWidget(QVLineBreakWidget(self))
 
         self.parameters_layout = QGridLayout()
         row_index = 0
         parameter_label = QLabel("Exposure duration:", self)
         parameter_editbox = QLineEdit(str(0.01), self)
-        parameter_slider = QSlider(Qt.Horizontal)
-        parameter_slider.setRange(0, 100)
-        parameter_slider.valueChanged.connect(
-            lambda: parameter_editbox.setText(str(parameter_slider.value() / 100))
-        )
 
         self.parameters_layout.addWidget(
             parameter_label, row_index, 0, alignment=Qt.AlignTop
         )
         self.parameters_layout.addWidget(
             parameter_editbox, row_index, 1, alignment=Qt.AlignTop
-        )
-        self.parameters_layout.addWidget(
-            parameter_slider, row_index, 2, alignment=Qt.AlignTop
         )
 
         self.main_layout.addLayout(self.parameters_layout)

--- a/copylot/gui/_qt/dockables/camera.py
+++ b/copylot/gui/_qt/dockables/camera.py
@@ -1,0 +1,53 @@
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QPushButton,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QSlider,
+)
+
+from copylot.gui._qt.custom_widgets.line_break import QVLineBreakWidget
+
+
+class CameraDockWidget(QWidget):
+    def __init__(self, parent):
+        super(QWidget, self).__init__(parent)
+        self.parent = parent
+
+        self.main_layout = QHBoxLayout()
+        self.power_button = QPushButton("Power")
+        self.power_button.clicked.connect(self.power_button.toggle)
+        self.main_layout.addWidget(self.power_button)
+
+        self.main_layout.addWidget(QVLineBreakWidget(self))
+
+        self.parameters_layout = QGridLayout()
+        row_index = 0
+        parameter_label = QLabel("Exposure duration:", self)
+        parameter_editbox = QLineEdit(str(0.01), self)
+        parameter_slider = QSlider(Qt.Horizontal)
+        parameter_slider.setRange(0, 100)
+        parameter_slider.valueChanged.connect(
+            lambda: parameter_editbox.setText(str(parameter_slider.value() / 100))
+        )
+
+        self.parameters_layout.addWidget(
+            parameter_label, row_index, 0, alignment=Qt.AlignTop
+        )
+        self.parameters_layout.addWidget(
+            parameter_editbox, row_index, 1, alignment=Qt.AlignTop
+        )
+        self.parameters_layout.addWidget(
+            parameter_slider, row_index, 2, alignment=Qt.AlignTop
+        )
+
+        self.main_layout.addLayout(self.parameters_layout)
+
+        self.setLayout(self.main_layout)
+
+    @property
+    def parameters(self):
+        raise NotImplementedError("camera.parameters not yet implemented")

--- a/copylot/gui/gui.py
+++ b/copylot/gui/gui.py
@@ -114,6 +114,10 @@ class MainWindow(QMainWindow):
         self.laser_dock.setTitleBarWidget(QLabel("Laser"))
         self.dock_list.append(self.laser_dock)
 
+        self.camera_dock = QDockWidget(self)
+        self.camera_dock.setTitleBarWidget(QLabel("Camera"))
+        self.dock_list.append(self.camera_dock)
+
         for dock in self.dock_list:
             _apply_dock_config(dock)
 
@@ -144,6 +148,10 @@ class MainWindow(QMainWindow):
             DockPlaceholder(self, self.laser_dock, "laser", [self])
         )
 
+        self.camera_dock.setWidget(
+            DockPlaceholder(self, self.camera_dock, "camera", [self])
+        )
+
         # self.parameters_widget = ParametersDockWidget(self)
         self.parameters_placeholder = DockPlaceholder(
             self, self.parameters_dock, "parameters", [self]
@@ -156,6 +164,7 @@ class MainWindow(QMainWindow):
         self.splitDockWidget(self.live_dock, self.timelapse_dock, Qt.Vertical)
         self.splitDockWidget(self.timelapse_dock, self.water_dock, Qt.Vertical)
         self.splitDockWidget(self.water_dock, self.laser_dock, Qt.Vertical)
+        self.splitDockWidget(self.laser_dock, self.camera_dock, Qt.Vertical)
 
         # create status bar that is updated from live and timelapse control classes
         self.status_bar = QStatusBar()

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -4,7 +4,7 @@ from pyvcam.camera import Camera
 
 class PrimeBSICamera:
     def __init__(self):
-        pass
+        pvc.init_pvcam()
 
     @staticmethod
     def available_cameras():
@@ -12,3 +12,6 @@ class PrimeBSICamera:
         print(f"Available cameras: {cameras}")
 
         return cameras
+
+    def __del__(self):
+        pvc.uninit_pvcam()

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -6,7 +6,9 @@ class PrimeBSICamera:
     def __init__(
             self,
             scan_mode,
+            scan_dir,
             binning: tuple,
+            enable_metadata: bool = True,
     ):
         """
 
@@ -21,7 +23,10 @@ class PrimeBSICamera:
         pvc.init_pvcam()
 
         self.cam.prog_scan_mode = scan_mode
+        self.cam.prog_scan_dir = scan_dir
         self.cam.binning = binning
+
+        self.cam.set_param(constants.PARAM_METADATA_ENABLED, enable_metadata)
 
     def __del__(self):
         pvc.uninit_pvcam()

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -6,6 +6,9 @@ class PrimeBSICamera:
     def __init__(self):
         pvc.init_pvcam()
 
+    def __del__(self):
+        pvc.uninit_pvcam()
+
     @staticmethod
     def available_cameras():
         cameras = Camera.get_available_camera_names()
@@ -13,5 +16,18 @@ class PrimeBSICamera:
 
         return cameras
 
-    def __del__(self):
-        pvc.uninit_pvcam()
+    def live_run(self, exposure: int = 20):
+        """
+        Live mode run method.
+
+        Parameters
+        ----------
+        exposure : int
+
+        Returns
+        -------
+
+        """
+        self.cam.start_live(exposure)
+
+        return self.cam.poll_frame

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -3,8 +3,15 @@ from pyvcam.camera import Camera
 
 
 class PrimeBSICamera:
-    def __init__(self):
+    def __init__(
+            self,
+            scan_mode,
+            binning: tuple,
+    ):
         pvc.init_pvcam()
+
+        self.cam.prog_scan_mode = scan_mode
+        self.cam.binning = binning
 
     def __del__(self):
         pvc.uninit_pvcam()
@@ -26,16 +33,12 @@ class PrimeBSICamera:
         return scan_modes
 
     @property
-    def scan_mode(self):
-        return self.cam.prog_scan_mode
+    def gain(self):
+        return self.cam.gain
 
-    @scan_mode.setter
-    def scan_mode(self, scan_mode):
-        self.cam.prog_scan_mode = scan_mode
-
-    @property
-    def binning(self):
-        return self.cam.binning
+    @gain.setter
+    def gain(self, gain):
+        self.cam.gain = gain
 
     @binning.setter
     def binning(self, x_bin, y_bin):

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -55,6 +55,28 @@ class PrimeBSICamera:
         """
         self.cam.binning = (x_bin, y_bin)
 
+    def reset_rois(self):
+        """Restores ROI to the default."""
+        self.cam.reset_rois()
+
+    def set_roi(self, s1: int, p1: int, width: int, height: int):
+        """
+        Adds a new ROI with given parameters to the list of ROIs.
+
+        Parameters
+        ----------
+        s1 : int
+            Serial coordinate of the first corner
+        p1 : int
+            Parallel coordinate of the first corner
+        width : int
+            Width of ROI in number of pixels
+        height : int
+            Height of ROI in number of pixels
+
+        """
+        self.cam.set_roi(s1, p1, width, height)
+
     def live_run(self, exposure: int = 20):
         """
         Live mode run method.

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -16,6 +16,15 @@ class PrimeBSICamera:
 
         return cameras
 
+    @staticmethod
+    def available_scan_modes():
+        cam = next(Camera.detect_camera())
+        scan_modes = cam.__prog_scan_modes
+
+        print(f"Available scan modes: {scan_modes}")
+
+        return scan_modes
+
     def live_run(self, exposure: int = 20):
         """
         Live mode run method.

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -1,0 +1,14 @@
+from pyvcam import pvc
+from pyvcam.camera import Camera
+
+
+class PrimeBSICamera:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def available_cameras():
+        cameras = Camera.get_available_camera_names()
+        print(f"Available cameras: {cameras}")
+
+        return cameras

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -8,6 +8,16 @@ class PrimeBSICamera:
             scan_mode,
             binning: tuple,
     ):
+        """
+
+        Parameters
+        ----------
+        scan_mode
+        binning : tuple
+            (x_bin, y_bin). If you want to set square
+            binning, you should pass equal values for
+            x_bin and y_bin.
+        """
         pvc.init_pvcam()
 
         self.cam.prog_scan_mode = scan_mode
@@ -39,21 +49,6 @@ class PrimeBSICamera:
     @gain.setter
     def gain(self, gain):
         self.cam.gain = gain
-
-    @binning.setter
-    def binning(self, x_bin, y_bin):
-        """
-        Binning property setter. If you want to set
-        square binning, you should pass equal values
-        for x_bin and y_bin.
-
-        Parameters
-        ----------
-        x_bin
-        y_bin
-
-        """
-        self.cam.binning = (x_bin, y_bin)
 
     def reset_rois(self):
         """Restores ROI to the default."""

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -50,6 +50,14 @@ class PrimeBSICamera:
     def gain(self, gain):
         self.cam.gain = gain
 
+    @property
+    def exposure_time(self):
+        return self.cam.exp_time
+
+    @exposure_time.setter
+    def exposure_time(self, exposure_time):
+        self.cam.exp_time = exposure_time
+
     def reset_rois(self):
         """Restores ROI to the default."""
         self.cam.reset_rois()

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -33,6 +33,25 @@ class PrimeBSICamera:
     def scan_mode(self, scan_mode):
         self.cam.prog_scan_mode = scan_mode
 
+    @property
+    def binning(self):
+        return self.cam.binning
+
+    @binning.setter
+    def binning(self, x_bin, y_bin):
+        """
+        Binning property setter. If you want to set
+        square binning, you should pass equal values
+        for x_bin and y_bin.
+
+        Parameters
+        ----------
+        x_bin
+        y_bin
+
+        """
+        self.cam.binning = (x_bin, y_bin)
+
     def live_run(self, exposure: int = 20):
         """
         Live mode run method.

--- a/copylot/hardware/prime_bsi_camera/camera.py
+++ b/copylot/hardware/prime_bsi_camera/camera.py
@@ -25,6 +25,14 @@ class PrimeBSICamera:
 
         return scan_modes
 
+    @property
+    def scan_mode(self):
+        return self.cam.prog_scan_mode
+
+    @scan_mode.setter
+    def scan_mode(self, scan_mode):
+        self.cam.prog_scan_mode = scan_mode
+
     def live_run(self, exposure: int = 20):
         """
         Live mode run method.

--- a/copylot/microscope_config/configs/mantis.yaml
+++ b/copylot/microscope_config/configs/mantis.yaml
@@ -2,3 +2,11 @@ name: mantis
 hardware:
   - ni_daq:
       show_gui: true
+  - prime_bsi_camera:
+      TRIGGER_MODE: "NORMAL"
+      TRIGGERPOLARITY: "POSITIVE"
+      TRIGGER_CONNECTOR: "BNC"
+      TRIGGERTIMES: 1
+      TRIGGERDELAY: 0
+      TRIGGERSOURCE: "EXTERNAL"
+      TRIGGERACTIVE: "SYNCREADOUT"


### PR DESCRIPTION
This PR adds the camera adapter required for using prime bsi camera and the initial form of the camera gui dockable widget. Eventually, we should be able to populate the parameters on that camera dockable widget with the exposed options of the related camera adapter instance. This is currently not implemented. Before merging the PR, we should also add a demo for the prime bsi camera and test it on the automaton machine.